### PR TITLE
README.mdを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # D言語クックブック
 [![CircleCI](https://circleci.com/gh/dlang-jp/Cookbook.svg?style=svg)](https://circleci.com/gh/dlang-jp/Cookbook)
 
+ドキュメント : [https://dlang-jp.github.io/Cookbook](https://dlang-jp.github.io/Cookbook)
+
 処理内容から書き方を逆引きするための資料です。
 
 実際に動くプログラム、そこから生成されるHTMLをまとめます。
@@ -9,13 +11,6 @@
 
 - D言語ツアー
 [https://tour.dlang.org/tour/ja/welcome/welcome-to-d](https://tour.dlang.org/tour/ja/welcome/welcome-to-d)
-
-# 目次
-ドキュメント : [https://dlang-jp.github.io/Cookbook](https://dlang-jp.github.io/Cookbook)
-
-1. [文字列操作](/source/string_example.d)
-2. [配列操作](/source/array_example.d)
-3. [引数解析](/source/getopt_example.d)
 
 # 使い方
 ## リポジトリ構成


### PR DESCRIPTION
- 目次と実際のドキュメントが対応してないため、目次欄を削除
- ドキュメントへのリンクを冒頭に移動

close #38 