### PR TITLE
gendocバージョンアップ対応とレイアウト微調整

### DIFF
--- a/source_docs/css/proj_docs.css
+++ b/source_docs/css/proj_docs.css
@@ -53,7 +53,11 @@ body > .container
 /* TC: Formats D / D_INLINECODE */
 .d_inlinecode
 {
-    font-weight: bold;
+    background: #f0f0f0;
+    border-radius: 3px;
+    padding: 0.2em 0.4em;
+    font-size: 85%;
+    margin: 0px;
 }
 
 /* SPAN: Formats D_COMMENT */
@@ -613,19 +617,19 @@ dt.ddoc_decl:hover .ddoc_decl_anchor
 /* The modules listed on the index page */
 .module_index_dubpkgname
 {
-    font-size: 1.5em;
+    font-size: 1.3rem;
     font-weight: bold;
 }
 .module_index
 {
-    font-size: 1.2em;
+    font-size: 1.1rem;
 }
 
 /* Customize how TABLEs look */
 table
 {
-    border: solid #640000;
-    border-width: 2px 2px 2px 2px;
+    border: solid #333;
+    border-width: 2px 0;
     border-collapse: collapse;
 }
 
@@ -644,27 +648,18 @@ table td, table th, table caption
 table td
 {
     border: none;
-    /* border-bottom: 1px solid #E6E6E6; */
-    border-bottom: 1px dotted #046000;
-    text-align: justify;
+    border-bottom: 1px solid #E6E6E6;
 }
 
 table th
 {
     border: none;
-    border-bottom: 2px solid #640000;
+    border-bottom: 1px solid #333;
 }
 
-table th:not(:last-child)
+table td:not(:last-child), table th:not(:last-child)
 {
     padding-right: 1em;
-    border-right: 1px solid #640000;
-}
-
-table td:not(:last-child)
-{
-    padding-right: 1em;
-    border-right: 1px dotted #640000;
 }
 
 table a


### PR DESCRIPTION
### インラインコードの背景色
> ![image](https://user-images.githubusercontent.com/580704/76682736-e17a0880-6641-11ea-8824-b083cf880789.png)

GitHubの感じに寄せた。

### テーブルのレイアウト調整
> ```d
> /* The response type corresponds to the request type.
>  * 
>  * | Request Type          | Response Type        |
>  * |:----------------------|:---------------------|
>  * | ReqEcho               | ResEcho, ResErr      |
>  * | ReqInfo               | ResInfo, ResErr      |
>  */
> ```
> ![image](https://user-images.githubusercontent.com/580704/76682801-58af9c80-6642-11ea-8e9f-ac2176be246c.png)

※まだCookbookでは表が使われていないので、gendocでの例。なんかレイアウト崩れてるけど、これはdmdが悪いと思う。

>```d
>/* stmcsv:
>  * $(TABLE
>  *   $(TR $(TH *MusicPlayer* )$(TH #>stop                   )$(TH #>play                                          )$(TH #>pause                 ) )
>  *   $(TR $(TH StartAct.     )$(TD                          )$(TD                                                 )$(TD                         ) )
>  *   $(TR $(TH EndAct.       )$(TD                          )$(TD                                                 )$(TD                         ) )
>  *   $(TR $(TH onStart       )$(TD #>play$(BR)- Start music )$(TD #>pause$(BR)- Stop music                        )$(TD #>play$(BR)- Start music) )
>  *   $(TR $(TH onStop        )$(TD                          )$(TD  #>stop$(BR)- Stop music$(BR)- Return to first  )$(TD #>stop$(BR)- Return to first) )
>  * )
>  * mapcsv:
>  * $(TABLE
>  *   $(TR $(TD #>stop            )$(TD stop           ) )
>  *   $(TR $(TD #>play            )$(TD play           ) )
>  *   $(TR $(TD #>pause           )$(TD pause          ) )
>  *   $(TR $(TD - Start music     )$(TD startMusic();  ) )
>  *   $(TR $(TD - Stop music      )$(TD stopMusic();   ) )
>  *   $(TR $(TD - Return to first )$(TD resetMusic();  ) )
>  * )
>  */ 
>```
> ![image](https://user-images.githubusercontent.com/580704/76682759-feaed700-6641-11ea-9577-616d1a229443.png)

※まだCookbookでは表が使われていないので、cushionでの例。

### Overviewのツリーでサブメニューが深くなると文字が大きくなる問題に対処
fix #80 
>![image](https://user-images.githubusercontent.com/580704/76682728-d2935600-6641-11ea-9090-e2b6200b0fef.png)

### ついでにWindowsでdmd 64bit版を使ってもテスト成功するようにした
Windowsでdmdの64bit版のほうにPATHが通っているとx86でのコンパイル後の実行時にlibcurl.dllのパスがおかしくなる。GitHub Actions限定ではあるけれど、runner.dのほうでコンパイル後のアーキテクチャに合わせてPATHを通しなおしている。
とはいえ、64bitバイナリのdubで`dub test -a=x86`とかするとダメなので、何とかしたいところだけれど、これは`dub test`の構造的欠陥な気がする。