### PR TITLE
Update setup-dlang

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -47,7 +47,7 @@ jobs:
   #  steps:
   #    - uses: actions/checkout@v2
   #    - name: Install D compiler
-  #      uses: mihails-strasuns/setup-dlang@v0.5.0
+  #      uses: dlang-community/setup-dlang@v1
   #      with:
   #        compiler: ${COMPILER}
   #    # テストをする場合は以下を実行
@@ -78,7 +78,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install D compiler
-        uses: mihails-strasuns/setup-dlang@v0.5.0
+        uses: dlang-community/setup-dlang@v1
         with:
           compiler: dmd-latest
       - name: Run unit tests
@@ -104,7 +104,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install D compiler
-        uses: mihails-strasuns/setup-dlang@v0.5.0
+        uses: dlang-community/setup-dlang@v1
         with:
           compiler: dmd-latest
       - name: Run unit tests
@@ -125,7 +125,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install D compiler
-        uses: mihails-strasuns/setup-dlang@v0.5.0
+        uses: dlang-community/setup-dlang@v1
         with:
           compiler: ldc-latest
       - name: Run unit tests
@@ -143,7 +143,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install D compiler
-        uses: mihails-strasuns/setup-dlang@v0.5.0
+        uses: dlang-community/setup-dlang@v1
         with:
           compiler: ldc-master
           gh_token: ${{ secrets.GITHUB_TOKEN }}
@@ -162,7 +162,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install D compiler
-        uses: mihails-strasuns/setup-dlang@v0.5.0
+        uses: dlang-community/setup-dlang@v1
         with:
           compiler: ldc-latest
       - name: Install dependencies
@@ -190,7 +190,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install D compiler
-        uses: mihails-strasuns/setup-dlang@v0.5.0
+        uses: dlang-community/setup-dlang@v1
         with:
           compiler: dmd-latest
       - name: Run unit tests
@@ -204,7 +204,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install D compiler
-        uses: mihails-strasuns/setup-dlang@v0.5.0
+        uses: dlang-community/setup-dlang@v1
         with:
           compiler: ldc-latest
       - name: Run unit tests
@@ -230,7 +230,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install D compiler
-        uses: mihails-strasuns/setup-dlang@v0.5.0
+        uses: dlang-community/setup-dlang@v1
         with:
           compiler: dmd-master
       - name: Run unit tests
@@ -265,7 +265,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install D compiler
-        uses: mihails-strasuns/setup-dlang@v0.5.0
+        uses: dlang-community/setup-dlang@v1
         with:
           compiler: dmd-latest
       - name: Run unit tests
@@ -279,7 +279,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install D compiler
-        uses: mihails-strasuns/setup-dlang@v0.5.0
+        uses: dlang-community/setup-dlang@v1
         with:
           compiler: ldc-latest
       - name: Run unit tests

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,7 +44,7 @@ jobs:
   #  steps:
   #    - uses: actions/checkout@v2
   #    - name: Install D compiler
-  #      uses: mihails-strasuns/setup-dlang@v0.5.0
+  #      uses: dlang-community/setup-dlang@v1
   #      with:
   #        compiler: ${COMPILER}
   #    # テストをする場合は以下を実行
@@ -75,7 +75,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install D compiler
-        uses: mihails-strasuns/setup-dlang@v0.5.0
+        uses: dlang-community/setup-dlang@v1
         with:
           compiler: dmd-latest
       - name: Run unit tests
@@ -101,7 +101,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install D compiler
-        uses: mihails-strasuns/setup-dlang@v0.5.0
+        uses: dlang-community/setup-dlang@v1
         with:
           compiler: dmd-latest
       - name: Run unit tests
@@ -122,7 +122,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install D compiler
-        uses: mihails-strasuns/setup-dlang@v0.5.0
+        uses: dlang-community/setup-dlang@v1
         with:
           compiler: ldc-latest
       - name: Run unit tests
@@ -140,7 +140,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install D compiler
-        uses: mihails-strasuns/setup-dlang@v0.5.0
+        uses: dlang-community/setup-dlang@v1
         with:
           compiler: ldc-master
           gh_token: ${{ secrets.GITHUB_TOKEN }}
@@ -159,7 +159,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install D compiler
-        uses: mihails-strasuns/setup-dlang@v0.5.0
+        uses: dlang-community/setup-dlang@v1
         with:
           compiler: ldc-latest
       - name: Install dependencies
@@ -187,7 +187,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install D compiler
-        uses: mihails-strasuns/setup-dlang@v0.5.0
+        uses: dlang-community/setup-dlang@v1
         with:
           compiler: dmd-latest
       - name: Run unit tests
@@ -201,7 +201,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install D compiler
-        uses: mihails-strasuns/setup-dlang@v0.5.0
+        uses: dlang-community/setup-dlang@v1
         with:
           compiler: ldc-latest
       - name: Run unit tests
@@ -227,7 +227,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install D compiler
-        uses: mihails-strasuns/setup-dlang@v0.5.0
+        uses: dlang-community/setup-dlang@v1
         with:
           compiler: dmd-master
       - name: Run unit tests
@@ -262,7 +262,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install D compiler
-        uses: mihails-strasuns/setup-dlang@v0.5.0
+        uses: dlang-community/setup-dlang@v1
         with:
           compiler: dmd-latest
       - name: Run unit tests
@@ -276,7 +276,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install D compiler
-        uses: mihails-strasuns/setup-dlang@v0.5.0
+        uses: dlang-community/setup-dlang@v1
         with:
           compiler: ldc-latest
       - name: Run unit tests


### PR DESCRIPTION
CIで使用していた`mihails-strasuns/setup-dlang@v0.5.0`がGitHub Actionsの破壊的変更により使えなくなってしまったので、`dlang-community/setup-dlang@v1`に移行。