### PR TITLE
gendocのバージョンアップ

### DIFF
--- a/.github/runner.d
+++ b/.github/runner.d
@@ -6,7 +6,7 @@ struct Defines
 static:
     /// ドキュメントジェネレータを指定します。
     /// gendocのバージョンが更新されたら変更してください。
-    immutable documentGenerator = "gendoc@0.0.5";
+    immutable documentGenerator = "gendoc@0.0.6";
     /// テスト対象にするサブパッケージを指定します。
     /// サブパッケージが追加されたらここにも追加してください。
     immutable subPkgs = ["windows", "libdparse_usage"];


### PR DESCRIPTION
See_Also: https://github.com/shoo/gendoc/releases/tag/v0.0.6
特に https://github.com/shoo/gendoc/pull/24/files これが入っているので、dubのgitリポジトリ指定に対応しています。