### PR TITLE
生成系のレンジの例を追加した

### DIFF
--- a/source/range_example.d
+++ b/source/range_example.d
@@ -226,3 +226,37 @@ unittest
     assert(r.take(4).equal([4, 8, 16, 32]));
 }
 
+/++
+漸化式のレンジを生成する`recurrence`の例です。
++/
+unittest
+{
+    import std.range;
+    import std.algorithm;
+
+    // recurrenceを使って階乗を計算します。
+    // 漸化式を文字列で指定可能です。
+    // aは状態を表す変数で、以前の実行結果が格納されます。
+    // nには現在の実行回数が格納されます。
+    // 関数の引数には初期状態を渡します。(漸化式が必要とする分だけ必要です)
+    // 以下のように書くと、
+    // 前回の実行結果 * 現在の実行回数(つまり階乗)を計算するレンジになります。
+    auto r = recurrence!"a[n - 1] * n"(1);
+    assert(r.front == 1); // 0!
+
+    // popFrontで漸化式の関数が実行されます。
+    r.popFront();
+    assert(r.front == 1); // 1!
+    r.popFront();
+    assert(r.front == 2); // 2!
+    r.popFront();
+    assert(r.front == 6); // 3!
+    r.popFront();
+    assert(r.front == 24); // 4!
+
+    // 複数の状態を持つ漸化式も表現可能です。
+    // 以下ではフィボナッチ数の計算を行います。
+    auto fib = recurrence!((a, n) => a[n - 2] + a[n - 1])(1, 1);
+    assert(fib.take(7).equal([1, 1, 2, 3, 5, 8, 13]));
+}
+

--- a/source/range_example.d
+++ b/source/range_example.d
@@ -137,3 +137,41 @@ unittest
     assert(equal(filter!"a % 2 != 0"(iota(0, 10)), [1, 3, 5, 7, 9]));
 }
 
+/++
+連番のレンジを作る`iota`の例です。
++/
+unittest
+{
+    import std.range;
+    import std.algorithm;
+
+    // 0〜4の5つの要素を持つレンジを作る例です。
+    assert(iota(5).equal([0, 1, 2, 3, 4]));
+
+    // [1, 5) の4つの要素を持つレンジを作る例です。
+    assert(iota(1, 5).equal([1, 2, 3, 4]));
+
+    // [1, 10) の範囲で2つおきの要素を持つレンジを作る例です。
+    assert(iota(1, 10, 2).equal([1, 3, 5, 7, 9]));
+}
+
+/++
+引数に指定した要素だけのレンジを作る`only`の例です。
++/
+unittest
+{
+    import std.range;
+    import std.algorithm;
+
+    // 指定要素だけを持つレンジを作れます。
+    assert(only(1).equal([1]));
+
+    // 複数指定も可能です。
+    assert(only(1, 2, 3).equal([1, 2, 3]));
+
+    // onlyでは動的メモリ確保無しでレンジを生成できます。
+    // ただし要素のコピーが発生するので、
+    // サイズが巨大になる場合は注意が必要です。
+    assert((() @nogc nothrow pure @safe => only(1, 2, 3))().equal([1, 2, 3]));
+}
+

--- a/source/range_example.d
+++ b/source/range_example.d
@@ -175,3 +175,28 @@ unittest
     assert((() @nogc nothrow pure @safe => only(1, 2, 3))().equal([1, 2, 3]));
 }
 
+/++
+引数に指定した要素を無限に繰り返す`repeat`の例です。
++/
+unittest
+{
+    import std.range;
+    import std.algorithm;
+
+    // 5を繰り返すレンジを作ります。
+    auto r = repeat(5);
+    assert(r.front == 5);
+    assert(!r.empty);
+
+    // 次の要素も5です。
+    r.popFront();
+    assert(r.front == 5);
+
+    // ランダムアクセスも可能です。
+    assert(r[0] == 5);
+    assert(r[1024] == 5);
+
+    // スライスも可能です。
+    assert(r[0 .. 5].equal([5, 5, 5, 5, 5]));
+}
+

--- a/source/range_example.d
+++ b/source/range_example.d
@@ -60,7 +60,7 @@ unittest
     {
         int i = 0;
         int n;
-        invariant(i <= n);
+        invariant (i <= n);
 
         /// nを指定するコンストラクタ
         this(int n)
@@ -91,6 +91,7 @@ unittest
 
     // 型がInputRangeであるかは、std.rangeのisInputRangeで確認できます。
     import std.range : isInputRange;
+
     static assert(isInputRange!IntRange);
 
     // InputRangeで行える操作は下記の通りです。
@@ -133,6 +134,7 @@ unittest
     // なお、IntRangeはより高機能なものがstd.rangeのiota関数として用意されています。
     // 自作せずにこちらを使用しましょう。
     import std.range : iota;
+
     assert(equal(iota(0, 5), IntRange(5)));
     assert(equal(filter!"a % 2 != 0"(iota(0, 10)), [1, 3, 5, 7, 9]));
 }
@@ -210,10 +212,7 @@ unittest
 
     // 関数(クロージャ)の戻り値をレンジにします。
     int value = 1;
-    auto r = generate!({
-        value *= 2;
-        return value;
-    });
+    auto r = generate!({ value *= 2; return value; });
 
     // 生成時に一度関数が実行されます。
     assert(r.front == 2);
@@ -259,4 +258,3 @@ unittest
     auto fib = recurrence!((a, n) => a[n - 2] + a[n - 1])(1, 1);
     assert(fib.take(7).equal([1, 1, 2, 3, 5, 8, 13]));
 }
-

--- a/source/range_example.d
+++ b/source/range_example.d
@@ -212,7 +212,7 @@ unittest
 
     // 関数(クロージャ)の戻り値をレンジにします。
     int value = 1;
-    auto r = generate!({ value *= 2; return value; });
+    auto r = generate!(() => value *= 2);
 
     // 生成時に一度関数が実行されます。
     assert(r.front == 2);

--- a/source/range_example.d
+++ b/source/range_example.d
@@ -200,3 +200,29 @@ unittest
     assert(r[0 .. 5].equal([5, 5, 5, 5, 5]));
 }
 
+/++
+指定された関数を使ってレンジを生成する`generate`の例です。
++/
+unittest
+{
+    import std.range;
+    import std.algorithm;
+
+    // 関数(クロージャ)の戻り値をレンジにします。
+    int value = 1;
+    auto r = generate!({
+        value *= 2;
+        return value;
+    });
+
+    // 生成時に一度関数が実行されます。
+    assert(r.front == 2);
+
+    // popFrontのたびに関数が実行されます。
+    r.popFront();
+    assert(r.front == 4);
+
+    // std.rangeのtakeで先頭から指定した数だけ要素を取り出せます。
+    assert(r.take(4).equal([4, 8, 16, 32]));
+}
+

--- a/source/range_example.d
+++ b/source/range_example.d
@@ -142,8 +142,8 @@ unittest
 +/
 unittest
 {
-    import std.range;
-    import std.algorithm;
+    import std.range : iota;
+    import std.algorithm : equal;
 
     // 0〜4の5つの要素を持つレンジを作る例です。
     assert(iota(5).equal([0, 1, 2, 3, 4]));
@@ -160,8 +160,8 @@ unittest
 +/
 unittest
 {
-    import std.range;
-    import std.algorithm;
+    import std.range : only;
+    import std.algorithm : equal;
 
     // 指定要素だけを持つレンジを作れます。
     assert(only(1).equal([1]));
@@ -180,8 +180,8 @@ unittest
 +/
 unittest
 {
-    import std.range;
-    import std.algorithm;
+    import std.range : repeat;
+    import std.algorithm : equal;
 
     // 5を繰り返すレンジを作ります。
     auto r = repeat(5);
@@ -205,8 +205,8 @@ unittest
 +/
 unittest
 {
-    import std.range;
-    import std.algorithm;
+    import std.range : generate, take;
+    import std.algorithm : equal;
 
     // 関数(クロージャ)の戻り値をレンジにします。
     int value = 1;
@@ -231,8 +231,8 @@ unittest
 +/
 unittest
 {
-    import std.range;
-    import std.algorithm;
+    import std.range : recurrence, take;
+    import std.algorithm : equal;
 
     // recurrenceを使って階乗を計算します。
     // 漸化式を文字列で指定可能です。


### PR DESCRIPTION
`std.range`の以下の関数の例を追加しました。

* `iota`
* `only`
* `repeat`
* `generate`
* `recurrence`