### PR TITLE
数値計算のサンプルを追加

### DIFF
--- a/source/numeric_example.d
+++ b/source/numeric_example.d
@@ -1,0 +1,61 @@
+/++
+数値計算
+
+標準ライブラリで提供される数値計算の関数などについてまとめます。
+
+主に `std.math` や `std.mathspecial`、 `std.numeric` を使った例を対象とします。
++/
+module numeric_example;
+
+/++
+浮動小数点数の同値判定の例です。
+
+浮動小数点数は計算の過程で誤差が出るため、相対誤差や絶対誤差を考慮して比較します。
+
+`std.math` の `isClose` を利用します。
++/
+unittest
+{
+    import std.math : isClose;
+
+    // float の場合と double の場合で異なる相対誤差が用いられます
+    assert(isClose(1.0f, 0.999_99f));
+    assert(!isClose(1.0, 0.999_99));
+    assert(isClose(1.0, 0.999_999_999));
+
+    // 第3引数で相対誤差を指定することができます
+    assert(isClose(1.0, 1.1, 0.1)); // 10%まで許容する
+}
+
+/++
+内積を計算する例です。
+
+`std.numeric` の `dotProduct` を利用します。
++/
+unittest
+{
+    import std.numeric : dotProduct;
+
+    auto a = [1.0, 2.0, 3.0];
+    auto b = [-1.0, 2.0, -3.0];
+
+    auto s = dotProduct(a, b);
+    assert(s == -6.0);
+}
+
+/++
+コサイン類似度を計算する例です。
+
+2つのレンジを受け取って、その類似度を0-1で返します。
++/
+unittest
+{
+    import std.math : isClose;
+    import std.numeric : cosineSimilarity;
+
+    auto a = [3.0, 2.0, 1.0, 1.0];
+    auto b = [2.0, 2.0, 1.0, 0.0];
+
+    auto s = cosineSimilarity(a, b);
+    assert(s.isClose(0.9467292624062573));
+}

--- a/source/numeric_example.d
+++ b/source/numeric_example.d
@@ -13,6 +13,8 @@ module numeric_example;
 浮動小数点数は計算の過程で誤差が出るため、相対誤差や絶対誤差を考慮して比較します。
 
 `std.math` の `isClose` を利用します。
+
+std.math.isClose : $(LINK https://dlang.org/phobos/std_math.html#.isClose)$(BR)
 +/
 unittest
 {
@@ -23,8 +25,9 @@ unittest
     assert(!isClose(1.0, 0.999_99));
     assert(isClose(1.0, 0.999_999_999));
 
-    // 第3引数で相対誤差を指定することができます
-    assert(isClose(1.0, 1.1, 0.1)); // 10%まで許容する
+    // isClose は、第3引数で相対誤差、第4引数で絶対誤差をそれぞれ指定します。
+    // 相対誤差は型によって異なり、絶対誤差の既定値は 0.0 です。
+    assert(isClose(1.0, 1.1, 0.1)); // 相対誤差10%まで許容し、絶対誤差は考慮しない
 }
 
 /++

--- a/source/unittests_example.d
+++ b/source/unittests_example.d
@@ -108,14 +108,16 @@ nothrow unittest
 /++
 浮動小数点数をテストする方法
 
-数値計算の結果は厳密なテストが難しいため、`approxEqual` を使い相対誤差などを利用した比較を行います。
+数値計算の結果は厳密なテストが難しいため `isClose` を使い相対誤差などを利用した比較を行います。
 
-std.math.approxEqual : $(LINK https://dlang.org/phobos/std_math.html#.approxEqual)$(BR)
+std.math.isClose : $(LINK https://dlang.org/phobos/std_math.html#.isClose)$(BR)
+
+類似の `approxEqual` はDMDのバージョンで非推奨となったため、 `isClose` を使うことが推奨されています。
 +/
 unittest
 {
     import std.numeric : secantMethod;
-    import std.math : approxEqual, cos;
+    import std.math : isClose, cos;
 
     float f(float x)
     {
@@ -124,11 +126,11 @@ unittest
 
     // セカント法を用いて区間内で関数fの結果が0になる引数（根）を探索します
     auto x = secantMethod!(f)(0f, 1f);
-    assert(approxEqual(x, 0.865474));
+    assert(isClose(x, 0.865474));
 
-    // approxEqual は、第3引数で相対誤差、第4引数で絶対誤差をそれぞれ指定します。
-    // それぞれ 0.01 と 0.00001 が既定値です。
-    assert(approxEqual(x, 0.865474, 0.01, 0.00001));
+    // isClose は、第3引数で相対誤差、第4引数で絶対誤差をそれぞれ指定します。
+    // 相対誤差は型によって異なり、絶対誤差の既定値は 0.0 です。
+    assert(isClose(x, 0.865474, 0.0001, 1e-6));
 
     // その他、こういった数値計算では結果の性質をテストすることも有効です。
     // これは一般に `Propety-based testing` と呼ばれる方法です。


### PR DESCRIPTION
まだ内容少ないですが、数値計算系で必要となる記述をまとめるモジュール追加しました。

`approxEqual` は 2.096.0 で非推奨になってしまったので `isClose` のみです。

`unittest` のモジュールにまだ `approxEqual` が残っているので `isClose` に書き換える必要がありそうですが、これは別件として対応したいと思います。