### PR TITLE
ドキュメント生成時のコンパイラ指定フラグを追加

### DIFF
--- a/.github/runner.d
+++ b/.github/runner.d
@@ -157,7 +157,7 @@ void generateDocument()
     string[string] env;
     env.addCurlPath();
     exec(["dub", "run", Defines.documentGenerator, "-y", "-a", config.arch,
-        "--", "-a", config.arch, "-b=release"], null, env);
+        "--", "-a", config.arch, "-b=release", "--compiler", config.compiler], null, env);
 
     // CircleCIでgh-pagesへのデプロイがビルドエラーになる件を回避
     auto circleCiConfigDir = config.scriptDir.buildPath("../docs/.circleci");


### PR DESCRIPTION
https://github.com/dlang-jp/Cookbook/pull/115/checks?check_run_id=2644890923
等のように、最近のGitHub Actionsの仕様変更？セットアップジョブの更新？のために、ドキュメント生成時にldc2より優先してgdcが使われてしまう問題を回避するため、--compilerフラグにてコンパイラを強制的に指定するようにした。