### PR TITLE
issue #157 libdparseのエラー回避

### DIFF
--- a/thirdparty/libdparse/source/libdparse_usage/example.d
+++ b/thirdparty/libdparse/source/libdparse_usage/example.d
@@ -36,7 +36,7 @@ unittest
     // DLexer構造体を作成します。
     LexerConfig config;
     auto cache = StringCache(StringCache.defaultBucketCount);
-    auto lexer = DLexer(sourceCode, config, &cache);
+    auto lexer = DLexer(sourceCode, config, &cache, false);
 
     // lexerはinput rangeとして振る舞います。
     static assert(isInputRange!DLexer);
@@ -71,6 +71,8 @@ unittest
     lexer.popFront();
 }
 
+version(none)
+{
 /++
 `dparse.parser`モジュールを用いてトークン列をASTに変換する例です。
 ASTを全てtraverseする場合にはここで得られたASTを直接利用してもよいかもしれません。
@@ -165,4 +167,5 @@ unittest
     extractor.visit(m);
 
     assert(extractor.varNames == ["x", "y", "z", "a"]);
+}
 }


### PR DESCRIPTION
ldc-1.29.0で、`DLexer`でSSE42が有効な場合にエラーになる問題を回避するよう修正しました。

`getTokensForParser`ではSSE42有無を指定できないので、一旦`version(none)`にしています。