### PR TITLE
ポート0を指定して未使用ポートを使用する

### DIFF
--- a/thirdparty/vibe-d/source/vibed_usage/_common.d
+++ b/thirdparty/vibe-d/source/vibed_usage/_common.d
@@ -7,10 +7,11 @@ module vibed_usage._common;
 
 /++
 利用していないポート番号を取得する
+
+単にポートに0を指定してlistenHTTPすることで、未使用のポートが割り当てられる。
+実際に割り当てられたポートはlistenHTTPの戻り値のbindAddressesを見ることで確認できる。
 +/
 ushort getUnusedPort() @safe
 {
-    import core.atomic;
-    shared static ushort _serial = 50_000;
-    return _serial.atomicOp!"+="(1);
+    return 0;
 }


### PR DESCRIPTION
vibe.dでまれにポートがかち合っているのか、listenできずに失敗するケースがある。
ポート0を指定すれば未使用ポートが使用されるので、ポート0を使用するように変更する。