### PR TITLE
わかりやすく適切なタイトルを設定

### DIFF
--- a/ddoc/custom.ddoc
+++ b/ddoc/custom.ddoc
@@ -2,4 +2,5 @@ _=Macros for customizing the output for a particular project
 
 PROJECT_ROOT=https://github.com/dlang-jp/Cookbook
 PROJECT_SRC_ROOT=$(PROJECT_ROOT)/tree/master
+PROJECT_TITLE=D言語クックブック
 _=

--- a/ddoc/main.ddoc
+++ b/ddoc/main.ddoc
@@ -10,7 +10,7 @@ $(T html,
         $(SCRIPTLOAD https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js)
         $(SCRIPTLOAD js/sidebar.js)
         $(SCRIPTLOAD js/listanchors.js)
-        $(T title, $(TITLE))
+        $(T title, $(TITLE) - $(PROJECT_TITLE))
         $(EXTRA_HEADERS)
         $(EXTRA_HEADERS2)
     )
@@ -49,7 +49,7 @@ $(DIVC sidebar-underbar)
 $(DIVC sidebar,
     $(DIVC head,
         $(AC githublinkimg, $(PROJECT_ROOT), <img src="img/GitHub-Mark-32px.png" width="32" height="32" />)
-        $(H2 $(PROJECT_NAME))
+        $(H2 $(PROJECT_TITLE))
         $(P $(SPANC smallprint, $(B version:) $(PROJECT_VERSION) $(SPANC separator, $(BR))
             )
         )

--- a/source_docs/index.dd
+++ b/source_docs/index.dd
@@ -4,4 +4,4 @@ $(H1 $(TITLE))
 $(MODULE_INDEX)
 
 Macros:
-    TITLE=Documentation for $(PROJECT_NAME)
+    TITLE=$(PROJECT_TITLE)


### PR DESCRIPTION
サイドバーとindexのタイトルを「D言語クックブック」に変更。
また、title要素の内容に`- D言語クックブック`を追加

例: `array_example` -> `array_example - D言語クックブック`

モジュール名がそのまま表示されている`array_example`の部分も`配列`のようにコメント中に書かれたタイトルになるとより良いと思いますが、けっこう手を入れないといけなさそうなのでサイト名を追加するにとどめました