### PR TITLE
Update GitHub Actions checkout to v3

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -45,7 +45,7 @@ jobs:
   #  name: test-${OS}-${ARCH}-${COMPILER}
   #  runs-on: ${OS}
   #  steps:
-  #    - uses: actions/checkout@v2
+  #    - uses: actions/checkout@v3
   #    - name: Install D compiler
   #      uses: dlang-community/setup-dlang@v1
   #      with:
@@ -76,7 +76,7 @@ jobs:
     name: test-windows-x86-dmd-latest
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install D compiler
         uses: dlang-community/setup-dlang@v1
         with:
@@ -102,7 +102,7 @@ jobs:
     name: test-windows-x86_64-dmd-latest
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install D compiler
         uses: dlang-community/setup-dlang@v1
         with:
@@ -123,7 +123,7 @@ jobs:
     name: test-windows-x86_64-ldc-latest
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install D compiler
         uses: dlang-community/setup-dlang@v1
         with:
@@ -141,7 +141,7 @@ jobs:
     name: test-windows-x86_64-ldc-master
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install D compiler
         uses: dlang-community/setup-dlang@v1
         with:
@@ -160,7 +160,7 @@ jobs:
     name: test-linux-x86-ldc-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install D compiler
         uses: dlang-community/setup-dlang@v1
         with:
@@ -186,7 +186,7 @@ jobs:
     name: test-linux-x86_64-dmd-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install D compiler
         uses: dlang-community/setup-dlang@v1
         with:
@@ -200,7 +200,7 @@ jobs:
     name: test-linux-x86_64-ldc-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install D compiler
         uses: dlang-community/setup-dlang@v1
         with:
@@ -226,7 +226,7 @@ jobs:
     name: test-linux-x86_64-dmd-master
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install D compiler
         uses: dlang-community/setup-dlang@v1
         with:
@@ -264,7 +264,7 @@ jobs:
     name: test-osx-x86_64-dmd-latest
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install D compiler
         uses: dlang-community/setup-dlang@v1
         with:
@@ -278,7 +278,7 @@ jobs:
     name: test-osx-x86_64-ldc-latest
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install D compiler
         uses: dlang-community/setup-dlang@v1
         with:
@@ -307,7 +307,7 @@ jobs:
     needs: [test-windows-x86-dmd-latest, test-windows-x86_64-dmd-latest, test-windows-x86_64-ldc-latest, test-windows-x86_64-ldc-master, test-linux-x86-ldc-latest, test-linux-x86_64-dmd-latest, test-linux-x86_64-ldc-latest, test-linux-x86_64-dmd-master, test-osx-x86_64-dmd-latest, test-osx-x86_64-ldc-latest]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download Windows coverage result
         uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,7 +42,7 @@ jobs:
   #  name: test-${OS}-${ARCH}-${COMPILER}
   #  runs-on: ${OS}
   #  steps:
-  #    - uses: actions/checkout@v2
+  #    - uses: actions/checkout@v3
   #    - name: Install D compiler
   #      uses: dlang-community/setup-dlang@v1
   #      with:
@@ -73,7 +73,7 @@ jobs:
     name: test-windows-x86-dmd-latest
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install D compiler
         uses: dlang-community/setup-dlang@v1
         with:
@@ -99,7 +99,7 @@ jobs:
     name: test-windows-x86_64-dmd-latest
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install D compiler
         uses: dlang-community/setup-dlang@v1
         with:
@@ -120,7 +120,7 @@ jobs:
     name: test-windows-x86_64-ldc-latest
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install D compiler
         uses: dlang-community/setup-dlang@v1
         with:
@@ -138,7 +138,7 @@ jobs:
     name: test-windows-x86_64-ldc-master
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install D compiler
         uses: dlang-community/setup-dlang@v1
         with:
@@ -157,7 +157,7 @@ jobs:
     name: test-linux-x86-ldc-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install D compiler
         uses: dlang-community/setup-dlang@v1
         with:
@@ -183,7 +183,7 @@ jobs:
     name: test-linux-x86_64-dmd-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install D compiler
         uses: dlang-community/setup-dlang@v1
         with:
@@ -197,7 +197,7 @@ jobs:
     name: test-linux-x86_64-ldc-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install D compiler
         uses: dlang-community/setup-dlang@v1
         with:
@@ -223,7 +223,7 @@ jobs:
     name: test-linux-x86_64-dmd-master
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install D compiler
         uses: dlang-community/setup-dlang@v1
         with:
@@ -261,7 +261,7 @@ jobs:
     name: test-osx-x86_64-dmd-latest
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install D compiler
         uses: dlang-community/setup-dlang@v1
         with:
@@ -275,7 +275,7 @@ jobs:
     name: test-osx-x86_64-ldc-latest
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install D compiler
         uses: dlang-community/setup-dlang@v1
         with:
@@ -304,7 +304,7 @@ jobs:
     needs: [test-windows-x86-dmd-latest, test-windows-x86_64-dmd-latest, test-windows-x86_64-ldc-latest, test-windows-x86_64-ldc-master, test-linux-x86-ldc-latest, test-linux-x86_64-dmd-latest, test-linux-x86_64-ldc-latest, test-linux-x86_64-dmd-master, test-osx-x86_64-dmd-latest, test-osx-x86_64-ldc-latest]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download Windows coverage result
         uses: actions/download-artifact@v1
         with:


### PR DESCRIPTION
GitHub Actionsのcheckout v2 -> v3の変更はEOLを迎えたnode.js v12からnode.js v16に上がっただけなので、影響はないはず。