### PR TITLE
Windows環境で不要な生成ファイルを除外

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ __dummy.html
 
 # Generated Files
 docs
+*.pdb
 
 # Hidden files
 .*


### PR DESCRIPTION
新しくコピーされるようになったファイルですが、不要のため除外設定に追加します