### PR TITLE
各ページのタイトルに日本語名を設定

### DIFF
--- a/source/array_example.d
+++ b/source/array_example.d
@@ -6,6 +6,8 @@
 要素の初期化、要素の追加、要素の削除、ソート(WIP)、ループ操作(WIP)
 
 Source: $(LINK_TO_SRC source/_array_example.d)
+Macros:
+    TITLE=配列を扱う例
 +/
 module array_example;
 

--- a/source/assoc_array_example.d
+++ b/source/assoc_array_example.d
@@ -4,6 +4,8 @@
 連想配列の操作についてまとめます。
 
 Source: $(LINK_TO_SRC source/_assoc_array_example.d)
+Macros:
+    TITLE=連想配列を扱う例
 +/
 module assoc_array_example;
 

--- a/source/concurrency_example.d
+++ b/source/concurrency_example.d
@@ -4,6 +4,8 @@
 `std.concurrency` を使った並行処理の例をまとめます。
 
 Source: $(LINK_TO_SRC source/_concurrency_example.d)
+Macros:
+    TITLE=並行処理の例
 +/
 module concurrency_example;
 

--- a/source/container_example.d
+++ b/source/container_example.d
@@ -4,6 +4,8 @@
 スタックやキューなど、いくつかのデータ構造を実現する方法についてまとめます。
 
 Source: $(LINK_TO_SRC source/_container_example.d)
+Macros:
+    TITLE=コンテナ（データ構造）の例
 +/
 module container_example;
 

--- a/source/datetime_example.d
+++ b/source/datetime_example.d
@@ -4,6 +4,8 @@
 時刻・日付の操作についてまとめます。
 
 Source: $(LINK_TO_SRC source/_datetime_example.d)
+Macros:
+    TITLE=時刻や日付操作の例
 +/
 module datetime_example;
 

--- a/source/exception_example.d
+++ b/source/exception_example.d
@@ -8,6 +8,8 @@ D言語は「例外機構」をもつ言語です。
 ここでは例外の使い方についてまとめます。
 
 Source: $(LINK_TO_SRC source/_exception_example.d)
+Macros:
+    TITLE=例外処理の例
 +/
 module exception_example;
 

--- a/source/file_example.d
+++ b/source/file_example.d
@@ -4,6 +4,8 @@
 ファイル・パス操作についてまとめます。
 
 Source: $(LINK_TO_SRC source/_file_example.d)
+Macros:
+    TITLE=ファイルとパス操作の例
 +/
 module file_example;
 

--- a/source/getopt_example.d
+++ b/source/getopt_example.d
@@ -6,6 +6,8 @@
 実行プログラムの引数を解析することができ、柔軟なプログラム作成を助けます。
 
 Source: $(LINK_TO_SRC source/_getopt_example.d)
+Macros:
+    TITLE=コマンドライン引数の解析例
 +/
 module getopt_example;
 

--- a/source/is_example.d
+++ b/source/is_example.d
@@ -4,6 +4,8 @@ is式
 is式についてまとめます。
 
 Source: $(LINK_TO_SRC source/_is_example.d)
+Macros:
+    TITLE=is式を使って様々な判定をする例
 +/
 module is_example;
 

--- a/source/meta_example.d
+++ b/source/meta_example.d
@@ -4,6 +4,8 @@
 メタプログラミングに出てくるイディオム等についてまとめます。
 
 Source: $(LINK_TO_SRC source/_meta_example.d)
+Macros:
+    TITLE=メタプログラミングおよび頻出イディオムの例
 +/
 module meta_example;
 

--- a/source/network_example.d
+++ b/source/network_example.d
@@ -6,6 +6,8 @@
 HTTP通信などができます。
 
 Source: $(LINK_TO_SRC source/_network_example.d)
+Macros:
+    TITLE=cURLを使ったネットワーク処理の例
 +/
 module network_example;
 

--- a/source/numeric_example.d
+++ b/source/numeric_example.d
@@ -6,6 +6,8 @@
 主に `std.math` や `std.mathspecial`、 `std.numeric` を使った例を対象とします。
 
 Source: $(LINK_TO_SRC source/_numeric_example.d)
+Macros:
+    TITLE=数値計算でよく利用される関数などの使用例
 +/
 module numeric_example;
 

--- a/source/opovl_excample.d
+++ b/source/opovl_excample.d
@@ -13,6 +13,8 @@ See_Also:
     - https://dlang.org/dstyle.html#operator_overloading
 
 Source: $(LINK_TO_SRC source/_opovl_excample.d)
+Macros:
+    TITLE=演算子オーバーロードの例
 +/
 module opovl_excample;
 

--- a/source/parallelism_example.d
+++ b/source/parallelism_example.d
@@ -4,6 +4,8 @@
 `std.parallelism` を使った並列処理の例をまとめます。
 
 Source: $(LINK_TO_SRC source/_parallelism_example.d)
+Macros:
+    TITLE=並列処理の例
 +/
 module parallelism_example;
 

--- a/source/process_example.d
+++ b/source/process_example.d
@@ -4,6 +4,8 @@
 プロセス操作についてまとめます。
 
 Source: $(LINK_TO_SRC source/_process_example.d)
+Macros:
+    TITLE=プロセス操作の例
 +/
 module process_example;
 

--- a/source/random_example.d
+++ b/source/random_example.d
@@ -4,6 +4,8 @@
 乱数操作についてまとめます。
 
 Source: $(LINK_TO_SRC source/_random_example.d)
+Macros:
+    TITLE=乱数操作の例
 +/
 module random_example;
 

--- a/source/range_example.d
+++ b/source/range_example.d
@@ -26,6 +26,8 @@ TODO:
 
 
 Source: $(LINK_TO_SRC source/_range_example.d)
+Macros:
+    TITLE=レンジを扱う処理の例
 +/
 module range_example;
 

--- a/source/regex_example.d
+++ b/source/regex_example.d
@@ -4,6 +4,8 @@
 正規表現の操作についてまとめます。
 
 Source: $(LINK_TO_SRC source/_regex_example.d)
+Macros:
+    TITLE=正規表現の例
 +/
 module regex_example;
 

--- a/source/string_example.d
+++ b/source/string_example.d
@@ -6,6 +6,8 @@
 TODO: 置換(replace), 削除(remove), 分割(split)
 
 Source: $(LINK_TO_SRC source/_string_example.d)
+Macros:
+    TITLE=文字列操作の例
 +/
 module string_example;
 

--- a/source/sumtype_example.d
+++ b/source/sumtype_example.d
@@ -6,6 +6,8 @@ SumTypeを使用すると、複数の型を複合した型を形成すること�
 
 See_Also:
     - https://dlang.org/phobos/std_sumtype.html
+Macros:
+    TITLE=SumType（タグ付き共用体）の例
 +/
 module sumtype_example;
 

--- a/source/sync_example.d
+++ b/source/sync_example.d
@@ -15,6 +15,8 @@
 - `Event`
 
 Source: $(LINK_TO_SRC source/_sync_example.d)
+Macros:
+    TITLE=同期処理と排他処理の例
 +/
 module sync_example;
 

--- a/source/template_example.d
+++ b/source/template_example.d
@@ -12,6 +12,8 @@ See_Also:
     - https://dlang.org/spec/template.html
 
 Source: $(LINK_TO_SRC source/_template_example.d)
+Macros:
+    TITLE=テンプレートの使用例
 +/
 module template_example;
 

--- a/source/typecons_example.d
+++ b/source/typecons_example.d
@@ -4,6 +4,8 @@
 様々な型を作れるtemplateを提供する`std.typecons`パッケージについて解説します。
 
 Source: $(LINK_TO_SRC source/_typecons_example.d)
+Macros:
+    TITLE=型を作るユーティリティ群の例
 +/
 module typecons_example;
 

--- a/source/uda_example.d
+++ b/source/uda_example.d
@@ -1,9 +1,11 @@
 /++
 UDA(User Defined Attribute)
 
-UDAの使用例についてまとめます。
+UDA(User Defined Attribute、ユーザー定義属性)の使用例についてまとめます。
 
 Source: $(LINK_TO_SRC source/_uda_example.d)
+Macros:
+    TITLE=ユーザー定義属性の例
 +/
 module uda_example;
 

--- a/source/unittests_example.d
+++ b/source/unittests_example.d
@@ -4,6 +4,8 @@
 様々な単体テストの記法についてまとめます。
 
 Source: $(LINK_TO_SRC source/_unittests_example.d)
+Macros:
+    TITLE=単体テストの例
 +/
 module unittests_example;
 


### PR DESCRIPTION
SEOや検索精度改善のため、各モジュールに対して日本語タイトルを設定しました。
メニュー名の部分だけだと説明力不足と思われたので、モジュール説明のうちタイトルの1つ下の段落をベースに短文で構成しています。

(Close #172)