### PR TITLE
tupleのコンパイル時の例のエラーを修正した。

### DIFF
--- a/source/typecons_example.d
+++ b/source/typecons_example.d
@@ -289,12 +289,8 @@ unittest
 
     // Tupleはコンパイル時にも利用可能です。
     enum staticTuple = tuple("test", 123);
-
-    // foreachによりフィールドを順に取り出すことができます。
-    static foreach (i, e; staticTuple[])
-    {
-        assert(t1[i] == e);
-    }
+    static assert(staticTuple[0] == "test");
+    static assert(staticTuple[1] == 123);
 
     // フィールドに名前の付いているTupleも作ることができます。
     // テンプレート引数に型・フィールド名のペアを指定すると、名前付きメンバーになります。


### PR DESCRIPTION
dmd-2.101.0-beta.1で発生するstd.typeconsの例のエラーを解消しました。

該当の`static foreach`を利用する方法がそもそもstd.typeconsのドキュメントに無かったため
(仕様範囲外? おそらくAliasSeqを使うのが正しい)
より無難な例に修正しました。

参考URL

https://dlang.org/phobos/std_typecons.html#.Tuple
https://dlang.org/articles/ctarguments.html