### PR TITLE
配列操作の例を追加

### DIFF
--- a/source/array_example.d
+++ b/source/array_example.d
@@ -103,9 +103,12 @@ unittest
 /++
 配列の一部の要素を置換します
 
+See_Also:
 - `replace` : $(LINK https://dlang.org/phobos/std_array.html#replace)
 - `replaceInPlace` : $(LINK https://dlang.org/phobos/std_array.html#replaceInPlace)
 - `replaceInto` : $(LINK https://dlang.org/phobos/std_array.html#replaceInto)
+
+$(WORKAROUND_ISSUE22230)
 +/
 unittest
 {
@@ -143,9 +146,12 @@ unittest
 /++
 配列の要素をシャッフルします
 
+See_Also:
 - `randomShuffle` : $(LINK https://dlang.org/phobos/std_random.html#randomShuffle)
 - `Random` : $(LINK https://dlang.org/phobos/std_random.html#Random)
 - `unpredictableSeed` : $(LINK https://dlang.org/phobos/std_random.html#unpredictableSeed)
+
+$(WORKAROUND_ISSUE22230)
 +/
 unittest
 {
@@ -193,10 +199,13 @@ unittest
 
 ※シャッフルの応用です
 
+See_Also:
 - `randomShuffle` : $(LINK https://dlang.org/phobos/std_random.html#randomShuffle)
 - `uniform` : $(LINK https://dlang.org/phobos/std_random.html#uniform)
 - `Random` : $(LINK https://dlang.org/phobos/std_random.html#Random)
 - `unpredictableSeed` : $(LINK https://dlang.org/phobos/std_random.html#unpredictableSeed)
+
+$(WORKAROUND_ISSUE22230)
 +/
 unittest
 {
@@ -247,8 +256,11 @@ unittest
 
 `std.algorithm` の `uniq` を使います。ただし、 `uniq` を使うにはその前にソートが必要です。
 
+See_Also:
 - `sort` : $(LINK https://dlang.org/phobos/std_algorithm_sorting.html#.sort)
 - `uniq` : $(LINK https://dlang.org/phobos/std_algorithm_iteration.html#.uniq)
+
+$(WORKAROUND_ISSUE22230)
 +/
 unittest
 {
@@ -272,8 +284,11 @@ unittest
 ソートしたくない場合にはuniqは使用できません。
 そのため、makeIndexでインデックスを一旦経由して重複削除し、mapでインデックスから要素を取り出します
 
+See_Also:
 - `sort` : $(LINK https://dlang.org/phobos/std_algorithm_sorting.html#.makeIndex)
 - `uniq` : $(LINK https://dlang.org/phobos/std_algorithm_iteration.html#.uniq)
+
+$(WORKAROUND_ISSUE22230)
 +/
 unittest
 {
@@ -304,6 +319,11 @@ unittest
 ソートしたくない場合、ということはきっとGCとか使いたくないしなるべく効率的なものが望ましいのでしょう。 `@nogc` で成り立つ例を紹介します。
 以下のアルゴリズムは `[a,b,c,d]` の配列では、 `a == b, a == c, b == c, a == d, b == d, c == d` の順番で比較し、一致したら都度その要素を末尾に持っていってはじく処理を行っています。
 removeでなくbringToFrontを使用する理由は、無駄な要素削除を行わないようにするためです。(内部でswapが行われるので、要素の上書き更新が発生しない)
+
+See_Also:
+- `bringToFront`: $(LINK https://dlang.org/phobos/std_algorithm_mutation.html#.bringToFront)
+
+$(WORKAROUND_ISSUE22230)
 +/
 unittest
 {

--- a/source/array_example.d
+++ b/source/array_example.d
@@ -103,9 +103,9 @@ unittest
 /++
 配列の一部の要素を置換します
 
-`replace` : $(LINK https://dlang.org/phobos/std_array.html#replace)
-`replaceInPlace` : $(LINK https://dlang.org/phobos/std_array.html#replaceInPlace)
-`replaceInto` : $(LINK https://dlang.org/phobos/std_array.html#replaceInto)
+- `replace` : $(LINK https://dlang.org/phobos/std_array.html#replace)
+- `replaceInPlace` : $(LINK https://dlang.org/phobos/std_array.html#replaceInPlace)
+- `replaceInto` : $(LINK https://dlang.org/phobos/std_array.html#replaceInto)
 +/
 unittest
 {
@@ -143,25 +143,48 @@ unittest
 /++
 配列の要素をシャッフルします
 
-- `Random` : $(LINK https://dlang.org/phobos/std_random.html#Random)
 - `randomShuffle` : $(LINK https://dlang.org/phobos/std_random.html#randomShuffle)
+- `Random` : $(LINK https://dlang.org/phobos/std_random.html#Random)
 - `unpredictableSeed` : $(LINK https://dlang.org/phobos/std_random.html#unpredictableSeed)
 +/
 unittest
 {
-    import std.random: randomShuffle, Random, unpredictableSeed;
-    // 個のサンプルでは結果を一定にするためシードを0に固定した乱数を使う
-    auto rnd = Random(0);
-    // 実際にはシードを unpredictableSeed で指定するなどすると良い
-    version (none)
-        rnd = Random(unpredictableSeed);
+    import std.random: randomShuffle, Random, Mt19937, unpredictableSeed;
+    version (unittest)
+    {
+        // このサンプルでは結果を一定にするためシードを0に固定し、
+        // メルセンヌツイスターを使用した乱数を使う
+        auto rnd = Mt19937(0);
+    }
+    else
+    {
+        // 実際にはお勧め乱数生成器のRandomを使用して、
+        // シードを unpredictableSeed で指定するなどすると良い
+        auto rnd = Random(unpredictableSeed);
+    }
 
     int[] data = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
 
     // シャッフルしたデータにインプレースで更新される。
     data.randomShuffle(rnd);
 
-    assert(data == [40, 70, 60, 100, 30, 80, 10, 50, 90, 20]);
+    // 中身はランダムに変化している
+    assert(data != [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]);
+
+    version (X86)
+    {
+        // randomShuffleの結果は配列のlengthのbit数=ターゲットアーキテクチャのビット数で変わる
+        // 32bitだと以下。
+        static assert(data.length.sizeof*8 == 32);
+        assert(data == [50, 20, 80, 60, 40, 100, 10, 90, 70, 30]);
+    }
+    version (X86_64)
+    {
+        // randomShuffleの結果は配列のlengthのbit数=ターゲットアーキテクチャのビット数で変わる
+        // 64bitだと以下。
+        static assert(data.length.sizeof*8 == 64);
+        assert(data == [40, 70, 60, 100, 30, 80, 10, 50, 90, 20]);
+    }
 }
 
 
@@ -170,15 +193,26 @@ unittest
 
 ※シャッフルの応用です
 
-`Random` : $(LINK https://dlang.org/phobos/std_random.html#Random)
-`randomShuffle` : $(LINK https://dlang.org/phobos/std_random.html#randomShuffle)
-`uniform` : $(LINK https://dlang.org/phobos/std_random.html#uniform)
+- `randomShuffle` : $(LINK https://dlang.org/phobos/std_random.html#randomShuffle)
+- `uniform` : $(LINK https://dlang.org/phobos/std_random.html#uniform)
+- `Random` : $(LINK https://dlang.org/phobos/std_random.html#Random)
+- `unpredictableSeed` : $(LINK https://dlang.org/phobos/std_random.html#unpredictableSeed)
 +/
 unittest
 {
-    import std.random: randomShuffle, Random, uniform;
-    // シードを0に固定した乱数を使う
-    auto rnd = Random(0);
+    import std.random: randomShuffle, Random, Mt19937, unpredictableSeed, uniform;
+    version (unittest)
+    {
+        // このサンプルでは結果を一定にするためシードを0に固定し、
+        // メルセンヌツイスターを使用した乱数を使う
+        auto rnd = Mt19937(0);
+    }
+    else
+    {
+        // 実際にはお勧め乱数生成器のRandomを使用して、
+        // シードを unpredictableSeed で指定するなどすると良い
+        auto rnd = Random(unpredictableSeed);
+    }
 
     int[] data = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
 
@@ -186,7 +220,24 @@ unittest
     // その中から0～(配列長)個取り出す。
     data = data.randomShuffle(rnd)[0..uniform(0, data.length, rnd)];
 
-    assert(data == [40, 70, 60, 100, 30]);
+    // 中身はランダムに変化しているし、長さも変わる
+    assert(data.length != 10);
+    assert(data != [10, 20, 30, 40, 50, 60, 70, 80, 90, 100][0..data.length]);
+
+    version (X86)
+    {
+        // randomShuffleの結果は配列のlengthのbit数=ターゲットアーキテクチャのビット数で変わる
+        // 32bitだと以下。
+        static assert(data.length.sizeof*8 == 32);
+        assert(data == [50]);
+    }
+    version (X86_64)
+    {
+        // randomShuffleの結果は配列のlengthのbit数=ターゲットアーキテクチャのビット数で変わる
+        // 64bitだと以下。
+        static assert(data.length.sizeof*8 == 64);
+        assert(data == [40, 70, 60, 100, 30]);
+    }
 }
 
 
@@ -196,8 +247,8 @@ unittest
 
 `std.algorithm` の `uniq` を使います。ただし、 `uniq` を使うにはその前にソートが必要です。
 
-`sort` : $(LINK https://dlang.org/phobos/std_algorithm_sorting.html#.sort)
-`uniq` : $(LINK https://dlang.org/phobos/std_algorithm_iteration.html#.uniq)
+- `sort` : $(LINK https://dlang.org/phobos/std_algorithm_sorting.html#.sort)
+- `uniq` : $(LINK https://dlang.org/phobos/std_algorithm_iteration.html#.uniq)
 +/
 unittest
 {
@@ -221,8 +272,8 @@ unittest
 ソートしたくない場合にはuniqは使用できません。
 そのため、makeIndexでインデックスを一旦経由して重複削除し、mapでインデックスから要素を取り出します
 
-`sort` : $(LINK https://dlang.org/phobos/std_algorithm_sorting.html#.makeIndex)
-`uniq` : $(LINK https://dlang.org/phobos/std_algorithm_iteration.html#.uniq)
+- `sort` : $(LINK https://dlang.org/phobos/std_algorithm_sorting.html#.makeIndex)
+- `uniq` : $(LINK https://dlang.org/phobos/std_algorithm_iteration.html#.uniq)
 +/
 unittest
 {


### PR DESCRIPTION
以下の例を追加します。

- 置換の例
- シャッフル
- 重複削除