### PR TITLE
Fix #189 LDC1.32でCIが動かないためコンパイラバージョンを固定する

### DIFF
--- a/.github/runner.d
+++ b/.github/runner.d
@@ -21,7 +21,8 @@ static:
     immutable subPkgs = [
         PackageInfo("asdf_usage"),
         PackageInfo("libdparse_usage"),
-        PackageInfo("vibe-d_usage", ["windows-x86_omf-", "linux-x86-", "osx-x86-"]),
+        // workaround https://github.com/dlang-jp/Cookbook/issues/198
+        PackageInfo("vibe-d_usage", ["windows-x86_omf-", "linux-x86-", "osx-x86-", "osx-x86_64-"]),
         PackageInfo("windows"),
     ];
 }

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -118,33 +118,19 @@ jobs:
           name: coverage-windows
           path: .cov
 
-  test-windows-x86_64-ldc-1_31:
-    name: test-windows-x86_64-ldc-1_31
+  # No. OS      ARCH    COMPILER   UT  DOC COV
+  #  6. Windows x86_64  ldc        o   x   x
+  test-windows-x86_64-ldc-latest:
+    name: test-windows-x86_64-ldc-latest
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install D compiler
         uses: dlang-community/setup-dlang@v1
         with:
-          compiler: ldc-1.31.0
+          compiler: ldc-latest
       - name: Run unit tests
         run: rdmd ./.github/runner.d -a=x86_64 --mode=unit-test
-
-  # No. OS      ARCH    COMPILER   UT  DOC COV
-  #  6. Windows x86_64  ldc        o   x   x
-  # LDC1.32で動かなくなったので一旦停止します
-  # https://github.com/dlang-jp/Cookbook/issues/189
-  # test-windows-x86_64-ldc-latest:
-  #   name: test-windows-x86_64-ldc-latest
-  #   runs-on: windows-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Install D compiler
-  #       uses: dlang-community/setup-dlang@v1
-  #       with:
-  #         compiler: ldc-latest
-  #     - name: Run unit tests
-  #       run: rdmd ./.github/runner.d -a=x86_64 --mode=unit-test
 
   # No. OS      ARCH    COMPILER   UT  DOC COV
   #  7. Windows x86_64  dmd-master x   x   x   x
@@ -152,20 +138,18 @@ jobs:
 
   # No. OS      ARCH    COMPILER   UT  DOC COV
   #  8. Windows x86_64  ldc-master o   x   x
-  # LDC1.32で動かなくなったので一旦停止します
-  # https://github.com/dlang-jp/Cookbook/issues/189
-  # test-windows-x86_64-ldc-master:
-  #   name: test-windows-x86_64-ldc-master
-  #   runs-on: windows-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Install D compiler
-  #       uses: dlang-community/setup-dlang@v1
-  #       with:
-  #         compiler: ldc-master
-  #         gh_token: ${{ secrets.GITHUB_TOKEN }}
-  #     - name: Run unit tests
-  #       run: rdmd ./.github/runner.d -a=x86_64 --mode=unit-test
+  test-windows-x86_64-ldc-master:
+    name: test-windows-x86_64-ldc-master
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install D compiler
+        uses: dlang-community/setup-dlang@v1
+        with:
+          compiler: ldc-master
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run unit tests
+        run: rdmd ./.github/runner.d -a=x86_64 --mode=unit-test
 
   # No. OS      ARCH    COMPILER   UT  DOC COV
   #  9. Ubuntu  x86     dmd        x   x   x
@@ -321,9 +305,8 @@ jobs:
     needs: [
       test-windows-x86-dmd-latest,
       test-windows-x86_64-dmd-latest,
-      test-windows-x86_64-ldc-1_31,
-      # test-windows-x86_64-ldc-latest,
-      # test-windows-x86_64-ldc-master,
+      test-windows-x86_64-ldc-latest,
+      test-windows-x86_64-ldc-master,
       test-linux-x86-ldc-latest,
       test-linux-x86_64-dmd-latest,
       test-linux-x86_64-ldc-latest,

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -113,34 +113,19 @@ jobs:
         with:
           name: coverage-windows
           path: .cov
-
-  test-windows-x86_64-ldc-1_31:
-    name: test-windows-x86_64-ldc-1_31
+  # No. OS      ARCH    COMPILER   UT  DOC COV
+  #  6. Windows x86_64  ldc        o   x   x
+  test-windows-x86_64-ldc-latest:
+    name: test-windows-x86_64-ldc-latest
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install D compiler
         uses: dlang-community/setup-dlang@v1
         with:
-          compiler: ldc-1.31.0
+          compiler: ldc-latest
       - name: Run unit tests
         run: rdmd ./.github/runner.d -a=x86_64 --mode=unit-test
-
-  # No. OS      ARCH    COMPILER   UT  DOC COV
-  #  6. Windows x86_64  ldc        o   x   x
-  # LDC1.32で動かなくなったので一旦停止します
-  # https://github.com/dlang-jp/Cookbook/issues/189
-  # test-windows-x86_64-ldc-latest:
-  #   name: test-windows-x86_64-ldc-latest
-  #   runs-on: windows-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Install D compiler
-  #       uses: dlang-community/setup-dlang@v1
-  #       with:
-  #         compiler: ldc-latest
-  #     - name: Run unit tests
-  #       run: rdmd ./.github/runner.d -a=x86_64 --mode=unit-test
 
   # No. OS      ARCH    COMPILER   UT  DOC COV
   #  7. Windows x86_64  dmd-master x   x   x   x
@@ -148,20 +133,18 @@ jobs:
 
   # No. OS      ARCH    COMPILER   UT  DOC COV
   #  8. Windows x86_64  ldc-master o   x   x
-  # LDC1.32で動かなくなったので一旦停止します
-  # https://github.com/dlang-jp/Cookbook/issues/189
-  # test-windows-x86_64-ldc-master:
-  #   name: test-windows-x86_64-ldc-master
-  #   runs-on: windows-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Install D compiler
-  #       uses: dlang-community/setup-dlang@v1
-  #       with:
-  #         compiler: ldc-master
-  #         gh_token: ${{ secrets.GITHUB_TOKEN }}
-  #     - name: Run unit tests
-  #       run: rdmd ./.github/runner.d -a=x86_64 --mode=unit-test
+  test-windows-x86_64-ldc-master:
+    name: test-windows-x86_64-ldc-master
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install D compiler
+        uses: dlang-community/setup-dlang@v1
+        with:
+          compiler: ldc-master
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run unit tests
+        run: rdmd ./.github/runner.d -a=x86_64 --mode=unit-test
 
   # No. OS      ARCH    COMPILER   UT  DOC COV
   #  9. Ubuntu  x86     dmd        x   x   x
@@ -317,9 +300,8 @@ jobs:
     needs: [
       test-windows-x86-dmd-latest,
       test-windows-x86_64-dmd-latest,
-      test-windows-x86_64-ldc-1_31,
-      # test-windows-x86_64-ldc-latest,
-      # test-windows-x86_64-ldc-master,
+      test-windows-x86_64-ldc-latest,
+      test-windows-x86_64-ldc-master,
       test-linux-x86-ldc-latest,
       test-linux-x86_64-dmd-latest,
       test-linux-x86_64-ldc-latest,

--- a/thirdparty/vibe-d/source/vibed_usage/rest.d
+++ b/thirdparty/vibe-d/source/vibed_usage/rest.d
@@ -264,7 +264,7 @@ unittest
             thrown = e;
     });
 
-    auto exitCode = runApplication();
+    auto exitCode = runEventLoop();
     assert(exitCode == 0, "exit code: ".text(exitCode));
     assert(!thrown, thrown.toString());
 


### PR DESCRIPTION
1.34.0にて改善されたため、一時的にバージョンを固定していたもの解除する。
また、 #198 の回避策として、一時的に vibe.d のテスト対象から MacOS を外した。
ついでに #192 と #193 の競合を解決する。