### PR TITLE
Update actions-gh-pages

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -344,13 +344,12 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: docs
+          path: docs
       - name: Deploy pages
-        uses: peaceiris/actions-gh-pages@v2
-        env:
-          ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-          PUBLISH_BRANCH: gh-pages
-          PUBLISH_DIR: docs
+        uses: peaceiris/actions-gh-pages@v3
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs
           emptyCommits: false
           user_name: GitHub Actions Bot
           user_email: <>


### PR DESCRIPTION
ページが全消滅してしまったので、CI設定を見直します。

- download-artifact に path 設定を追加
- actions-gh-pages のバージョンアップ (v2 -> v3)
  - 環境変数でデプロイキーを指定していたのを、 with で `GITHUB_TOKEN` を指定するように変更
  - 環境変数でパス・ブランチを指定しているのを with で指定するように変更。(ブランチはデフォルトが `gh_pages` のため指定不要)